### PR TITLE
Fix for failing github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   build-dev:
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     steps:
       - uses: actions/checkout@v2
       - uses: textbook/git-checkout-submodule-action@2.1.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,12 @@ name: Rust
 
 on: [push, pull_request]
 
+env:
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
 jobs:
   build-dev:
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     steps:
       - uses: actions/checkout@v2
       - uses: textbook/git-checkout-submodule-action@2.1.1


### PR DESCRIPTION
Error:
    Error: Unable to process command '::set-env name=TF_HASH::33689c48ad5e00908cd59089ef1956e1478fda78' successfully.
    Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

	modified:   .github/workflows/rust.yml